### PR TITLE
Updated Filtering Logic

### DIFF
--- a/tests/apiLogs.test.ts
+++ b/tests/apiLogs.test.ts
@@ -74,4 +74,21 @@ describe("GET /api/v1/logs", () => {
       expect(element).toMatch(/pci/i);
     });
   });
+
+  it("200 OK - No empty lines", async () => {
+    const query = {
+      filename: "withEmptyLines.sample",
+      n: 1000,
+    };
+    const response = await request(app).get("/api/v1/logs").query(query);
+    expect(response.statusCode).toBe(200);
+    expect(response.body.log.filename).toEqual(
+      path.join(VAR_LOG_DIR, "withEmptyLines.sample"),
+    );
+    expect(response.body.log.count).toEqual(223);
+    expect(response.body.log.events).toHaveLength(223);
+    response.body.log.events.forEach((element: string) => {
+      expect(element).not.toBe("");
+    });
+  });
 });

--- a/tests/samples/linux_2k.sample
+++ b/tests/samples/linux_2k.sample
@@ -1,3 +1,4 @@
+bios
 Jun 14 15:16:01 combo sshd(pam_unix)[19939]: authentication failure; logname= uid=0 euid=0 tty=NODEVssh ruser= rhost=218.188.2.4 
 Jun 14 15:16:02 combo sshd(pam_unix)[19937]: check pass; user unknown
 Jun 14 15:16:02 combo sshd(pam_unix)[19937]: authentication failure; logname= uid=0 euid=0 tty=NODEVssh ruser= rhost=218.188.2.4 

--- a/tests/samples/withEmptyLines.sample
+++ b/tests/samples/withEmptyLines.sample
@@ -1,0 +1,238 @@
+
+Jun 15 12:12:34 combo sshd(pam_unix)[23397]: authentication failure; logname= uid=0 euid=0 tty=NODEVssh ruser= rhost=218.188.2.4 
+
+Jun 15 14:53:35 combo sshd(pam_unix)[23673]: authentication failure; logname= uid=0 euid=0 tty=NODEVssh ruser= rhost=061092085098.ctinets.com 
+Jun 15 14:53:35 combo sshd(pam_unix)[23674]: check pass; user unknown
+Jun 15 14:53:35 combo sshd(pam_unix)[23674]: authentication failure; logname= uid=0 euid=0 tty=NODEVssh ruser= rhost=061092085098.ctinets.com 
+Jun 15 14:53:36 combo sshd(pam_unix)[23678]: check pass; user unknown
+Jun 15 14:53:36 combo sshd(pam_unix)[23678]: authentication failure; logname= uid=0 euid=0 tty=NODEVssh ruser= rhost=061092085098.ctinets.com 
+Jun 15 14:53:36 combo sshd(pam_unix)[23677]: check pass; user unknown
+Jun 15 14:53:36 combo sshd(pam_unix)[23677]: authentication failure; logname= uid=0 euid=0 tty=NODEVssh ruser= rhost=061092085098.ctinets.com 
+Jun 15 20:05:31 combo sshd(pam_unix)[24138]: check pass; user unknown
+
+Jul  7 07:18:13 combo sshd(pam_unix)[12525]: session opened for user test by (uid=509)
+Jul  7 07:18:13 combo sshd(pam_unix)[12524]: session closed for user test
+Jul  7 07:18:13 combo sshd(pam_unix)[12527]: session opened for user test by (uid=509)
+Jul  7 07:18:14 combo sshd(pam_unix)[12525]: session closed for user test
+Jul  7 07:18:14 combo sshd(pam_unix)[12527]: session closed for user test
+Jul  7 08:06:12 combo gpm[2094]: *** info [mice.c(1766)]: 
+Jul  7 08:06:12 combo gpm[2094]: imps2: Auto-detected intellimouse PS/2
+Jul  7 08:06:15 combo login(pam_unix)[2421]: session opened for user root by LOGIN(uid=0)
+Jul  7 08:06:15 combo  -- root[2421]: ROOT LOGIN ON tty2
+Jul  7 08:09:10 combo login(pam_unix)[2421]: session closed for user root
+Jul  7 08:09:11 combo udev[12754]: removing device node '/udev/vcsa2'
+Jul  7 08:09:11 combo udev[12753]: removing device node '/udev/vcs2'
+Jul  7 08:09:11 combo udev[12777]: creating device node '/udev/vcs2'
+Jul  7 08:09:11 combo udev[12778]: creating device node '/udev/vcsa2'
+
+
+Jul  7 08:09:11 combo udev[12795]: creating device node '/udev/vcs2'
+Jul  7 08:09:11 combo udev[12798]: creating device node '/udev/vcsa2'
+Jul  7 14:18:55 combo sshd(pam_unix)[13317]: check pass; user unknown
+Jul  7 14:18:55 combo sshd(pam_unix)[13317]: authentication failure; logname= uid=0 euid=0 tty=NODEVssh ruser= rhost=c9063558.virtua.com.br 
+Jul  7 14:18:57 combo sshd(pam_unix)[13321]: check pass; user unknown
+Jul  7 14:18:57 combo sshd(pam_unix)[13321]: authentication failure; logname= uid=0 euid=0 tty=NODEVssh ruser= rhost=c9063558.virtua.com.br 
+Jul  7 14:18:58 combo sshd(pam_unix)[13318]: check pass; user unknown
+Jul  7 14:18:58 combo sshd(pam_unix)[13318]: authentication failure; logname= uid=0 euid=0 tty=NODEVssh ruser= rhost=c9063558.virtua.com.br 
+Jul  7 14:18:59 combo sshd(pam_unix)[13323]: check pass; user unknown
+Jul  7 14:18:59 combo sshd(pam_unix)[13323]: authentication failure; logname= uid=0 euid=0 tty=NODEVssh ruser= rhost=c9063558.virtua.com.br 
+Jul  7 16:33:52 combo ftpd[13521]: connection from 202.82.200.188 () at Thu Jul  7 16:33:52 2005 
+Jul  7 16:33:52 combo ftpd[13513]: connection from 202.82.200.188 () at Thu Jul  7 16:33:52 2005 
+Jul  7 16:33:52 combo ftpd[13511]: connection from 202.82.200.188 () at Thu Jul  7 16:33:52 2005 
+Jul  7 16:33:52 combo ftpd[13512]: connection from 202.82.200.188 () at Thu Jul  7 16:33:52 2005 
+Jul  7 16:33:52 combo ftpd[13516]: connection from 202.82.200.188 () at Thu Jul  7 16:33:52 2005 
+Jul  7 16:33:52 combo ftpd[13515]: connection from 202.82.200.188 () at Thu Jul  7 16:33:52 2005 
+Jul  7 16:33:52 combo ftpd[13518]: connection from 202.82.200.188 () at Thu Jul  7 16:33:52 2005 
+Jul  7 16:33:52 combo ftpd[13522]: connection from 202.82.200.188 () at Thu Jul  7 16:33:52 2005 
+Jul  7 16:33:52 combo ftpd[13517]: connection from 202.82.200.188 () at Thu Jul  7 16:33:52 2005 
+Jul  7 16:33:52 combo ftpd[13520]: connection from 202.82.200.188 () at Thu Jul  7 16:33:52 2005 
+Jul  7 16:33:52 combo ftpd[13519]: connection from 202.82.200.188 () at Thu Jul  7 16:33:52 2005 
+Jul  7 16:33:52 combo ftpd[13514]: connection from 202.82.200.188 () at Thu Jul  7 16:33:52 2005 
+Jul  7 23:09:45 combo ftpd[14105]: connection from 221.4.102.93 () at Thu Jul  7 23:09:45 2005 
+Jul  7 23:09:45 combo ftpd[14106]: connection from 221.4.102.93 () at Thu Jul  7 23:09:45 2005 
+Jul  7 23:09:45 combo ftpd[14103]: connection from 221.4.102.93 () at Thu Jul  7 23:09:45 2005 
+Jul  7 23:09:45 combo ftpd[14107]: connection from 221.4.102.93 () at Thu Jul  7 23:09:45 2005 
+Jul  7 23:09:45 combo ftpd[14104]: connection from 221.4.102.93 () at Thu Jul  7 23:09:45 2005 
+
+Jul  8 04:04:19 combo su(pam_unix)[14943]: session opened for user cyrus by (uid=0)
+Jul  8 04:04:19 combo su(pam_unix)[14943]: session closed for user cyrus
+Jul  8 04:04:20 combo logrotate: ALERT exited abnormally with [1]
+Jul  8 04:12:07 combo su(pam_unix)[19593]: session opened for user news by (uid=0)
+Jul  8 04:12:08 combo su(pam_unix)[19593]: session closed for user news
+Jul  8 20:14:55 combo sshd(pam_unix)[20963]: authentication failure; logname= uid=0 euid=0 tty=NODEVssh ruser= rhost=212.0.132.20  user=test
+Jul  8 20:14:56 combo sshd(pam_unix)[20969]: authentication failure; logname= uid=0 euid=0 tty=NODEVssh ruser= rhost=212.0.132.20  user=test
+Jul  8 20:14:56 combo sshd(pam_unix)[20968]: authentication failure; logname= uid=0 euid=0 tty=NODEVssh ruser= rhost=212.0.132.20  user=test
+Jul  8 20:14:56 combo sshd(pam_unix)[20964]: authentication failure; logname= uid=0 euid=0 tty=NODEVssh ruser= rhost=212.0.132.20  user=test
+Jul  9 04:04:23 combo su(pam_unix)[21991]: session opened for user cyrus by (uid=0)
+Jul  9 04:04:24 combo su(pam_unix)[21991]: session closed for user cyrus
+Jul  9 04:04:25 combo logrotate: ALERT exited abnormally with [1]
+Jul  9 04:10:11 combo su(pam_unix)[22368]: session opened for user news by (uid=0)
+Jul  9 04:10:12 combo su(pam_unix)[22368]: session closed for user news
+Jul  9 11:35:59 combo ftpd[23028]: connection from 211.57.88.250 () at Sat Jul  9 11:35:59 2005 
+Jul  9 11:35:59 combo ftpd[23027]: connection from 211.57.88.250 () at Sat Jul  9 11:35:59 2005 
+Jul  9 11:35:59 combo ftpd[23026]: connection from 211.57.88.250 () at Sat Jul  9 11:35:59 2005 
+Jul  9 11:35:59 combo ftpd[23032]: connection from 211.57.88.250 () at Sat Jul  9 11:35:59 2005 
+Jul  9 11:35:59 combo ftpd[23030]: connection from 211.57.88.250 () at Sat Jul  9 11:35:59 2005 
+Jul  9 11:35:59 combo ftpd[23031]: connection from 211.57.88.250 () at Sat Jul  9 11:35:59 2005 
+Jul  9 11:35:59 combo ftpd[23035]: connection from 211.57.88.250 () at Sat Jul  9 11:35:59 2005 
+Jul  9 11:35:59 combo ftpd[23038]: connection from 211.57.88.250 () at Sat Jul  9 11:35:59 2005 
+Jul  9 11:35:59 combo ftpd[23037]: connection from 211.57.88.250 () at Sat Jul  9 11:35:59 2005 
+Jul  9 11:35:59 combo ftpd[23029]: connection from 211.57.88.250 () at Sat Jul  9 11:35:59 2005 
+Jul  9 11:35:59 combo ftpd[23036]: connection from 211.57.88.250 () at Sat Jul  9 11:35:59 2005 
+Jul  9 11:35:59 combo ftpd[23046]: connection from 211.57.88.250 () at Sat Jul  9 11:35:59 2005 
+Jul  9 11:35:59 combo ftpd[23048]: connection from 211.57.88.250 () at Sat Jul  9 11:35:59 2005 
+Jul  9 11:35:59 combo ftpd[23045]: connection from 211.57.88.250 () at Sat Jul  9 11:35:59 2005 
+Jul  9 11:35:59 combo ftpd[23043]: connection from 211.57.88.250 () at Sat Jul  9 11:35:59 2005 
+Jul  9 11:35:59 combo ftpd[23040]: connection from 211.57.88.250 () at Sat Jul  9 11:35:59 2005 
+Jul  9 11:35:59 combo ftpd[23044]: connection from 211.57.88.250 () at Sat Jul  9 11:35:59 2005 
+Jul  9 11:35:59 combo ftpd[23039]: connection from 211.57.88.250 () at Sat Jul  9 11:35:59 2005 
+Jul  9 11:35:59 combo ftpd[23041]: connection from 211.57.88.250 () at Sat Jul  9 11:35:59 2005 
+
+
+Jul  9 12:16:49 combo ftpd[23141]: connection from 211.167.68.59 () at Sat Jul  9 12:16:49 2005 
+Jul  9 12:16:49 combo ftpd[23144]: connection from 211.167.68.59 () at Sat Jul  9 12:16:49 2005 
+Jul  9 12:16:49 combo ftpd[23145]: connection from 211.167.68.59 () at Sat Jul  9 12:16:49 2005 
+Jul  9 12:16:49 combo ftpd[23146]: connection from 211.167.68.59 () at Sat Jul  9 12:16:49 2005 
+Jul  9 12:16:49 combo ftpd[23148]: connection from 211.167.68.59 () at Sat Jul  9 12:16:49 2005 
+Jul  9 12:16:49 combo ftpd[23149]: connection from 211.167.68.59 () at Sat Jul  9 12:16:49 2005 
+Jul  9 12:16:49 combo ftpd[23150]: connection from 211.167.68.59 () at Sat Jul  9 12:16:49 2005 
+Jul  9 12:16:49 combo ftpd[23147]: connection from 211.167.68.59 () at Sat Jul  9 12:16:49 2005 
+Jul  9 12:16:51 combo ftpd[23151]: connection from 211.167.68.59 () at Sat Jul  9 12:16:51 2005 
+Jul  9 12:16:51 combo ftpd[23152]: connection from 211.167.68.59 () at Sat Jul  9 12:16:51 2005 
+Jul  9 12:16:51 combo ftpd[23153]: connection from 211.167.68.59 () at Sat Jul  9 12:16:51 2005 
+Jul  9 12:16:51 combo ftpd[23155]: connection from 211.167.68.59 () at Sat Jul  9 12:16:51 2005 
+Jul  9 12:16:51 combo ftpd[23154]: connection from 211.167.68.59 () at Sat Jul  9 12:16:51 2005 
+Jul  9 12:16:52 combo ftpd[23156]: connection from 211.167.68.59 () at Sat Jul  9 12:16:52 2005 
+Jul  9 12:16:52 combo ftpd[23157]: connection from 211.167.68.59 () at Sat Jul  9 12:16:52 2005 
+Jul  9 12:59:44 combo ftpd[23204]: connection from 81.171.220.226 () at Sat Jul  9 12:59:44 2005 
+Jul  9 12:59:44 combo ftpd[23216]: connection from 81.171.220.226 () at Sat Jul  9 12:59:44 2005 
+Jul  9 12:59:44 combo ftpd[23215]: connection from 81.171.220.226 () at Sat Jul  9 12:59:44 2005 
+Jul  9 12:59:44 combo ftpd[23205]: connection from 81.171.220.226 () at Sat Jul  9 12:59:44 2005 
+Jul  9 12:59:44 combo ftpd[23217]: connection from 81.171.220.226 () at Sat Jul  9 12:59:44 2005 
+Jul  9 12:59:44 combo ftpd[23206]: connection from 81.171.220.226 () at Sat Jul  9 12:59:44 2005 
+Jul  9 12:59:44 combo ftpd[23207]: connection from 81.171.220.226 () at Sat Jul  9 12:59:44 2005 
+Jul  9 12:59:44 combo ftpd[23208]: connection from 81.171.220.226 () at Sat Jul  9 12:59:44 2005 
+Jul  9 12:59:44 combo ftpd[23209]: connection from 81.171.220.226 () at Sat Jul  9 12:59:44 2005 
+Jul  9 12:59:44 combo ftpd[23219]: connection from 81.171.220.226 () at Sat Jul  9 12:59:44 2005 
+Jul  9 12:59:44 combo ftpd[23210]: connection from 81.171.220.226 () at Sat Jul  9 12:59:44 2005 
+Jul  9 12:59:44 combo ftpd[23218]: connection from 81.171.220.226 () at Sat Jul  9 12:59:44 2005 
+Jul  9 12:59:44 combo ftpd[23213]: connection from 81.171.220.226 () at Sat Jul  9 12:59:44 2005 
+Jul  9 12:59:44 combo ftpd[23212]: connection from 81.171.220.226 () at Sat Jul  9 12:59:44 2005 
+Jul  9 12:59:44 combo ftpd[23211]: connection from 81.171.220.226 () at Sat Jul  9 12:59:44 2005 
+Jul  9 12:59:44 combo ftpd[23220]: connection from 81.171.220.226 () at Sat Jul  9 12:59:44 2005 
+Jul  9 12:59:44 combo ftpd[23214]: connection from 81.171.220.226 () at Sat Jul  9 12:59:44 2005 
+Jul  9 12:59:44 combo ftpd[23221]: connection from 81.171.220.226 () at Sat Jul  9 12:59:44 2005 
+Jul  9 12:59:45 combo ftpd[23222]: connection from 81.171.220.226 () at Sat Jul  9 12:59:45 2005 
+Jul  9 12:59:45 combo ftpd[23223]: connection from 81.171.220.226 () at Sat Jul  9 12:59:45 2005 
+Jul  9 12:59:45 combo ftpd[23224]: connection from 81.171.220.226 () at Sat Jul  9 12:59:45 2005 
+Jul  9 12:59:45 combo ftpd[23225]: connection from 81.171.220.226 () at Sat Jul  9 12:59:45 2005 
+Jul  9 12:59:45 combo ftpd[23226]: connection from 81.171.220.226 () at Sat Jul  9 12:59:45 2005 
+Jul  9 19:34:06 combo sshd(pam_unix)[23780]: authentication failure; logname= uid=0 euid=0 tty=NODEVssh ruser= rhost=p15105218.pureserver.info  user=root
+Jul  9 19:34:06 combo sshd(pam_unix)[23781]: authentication failure; logname= uid=0 euid=0 tty=NODEVssh ruser= rhost=p15105218.pureserver.info  user=root
+Jul  9 19:34:06 combo sshd(pam_unix)[23784]: authentication failure; logname= uid=0 euid=0 tty=NODEVssh ruser= rhost=p15105218.pureserver.info  user=root
+Jul  9 19:34:07 combo sshd(pam_unix)[23786]: authentication failure; logname= uid=0 euid=0 tty=NODEVssh ruser= rhost=p15105218.pureserver.info  user=root
+Jul  9 19:34:09 combo sshd(pam_unix)[23788]: authentication failure; logname= uid=0 euid=0 tty=NODEVssh ruser= rhost=p15105218.pureserver.info  user=root
+Jul  9 19:34:09 combo sshd(pam_unix)[23790]: authentication failure; logname= uid=0 euid=0 tty=NODEVssh ruser= rhost=p15105218.pureserver.info  user=root
+Jul  9 19:34:10 combo sshd(pam_unix)[23792]: authentication failure; logname= uid=0 euid=0 tty=NODEVssh ruser= rhost=p15105218.pureserver.info  user=root
+Jul  9 19:34:12 combo sshd(pam_unix)[23794]: authentication failure; logname= uid=0 euid=0 tty=NODEVssh ruser= rhost=p15105218.pureserver.info  user=root
+Jul  9 19:34:13 combo sshd(pam_unix)[23796]: authentication failure; logname= uid=0 euid=0 tty=NODEVssh ruser= rhost=p15105218.pureserver.info  user=root
+Jul  9 19:34:14 combo sshd(pam_unix)[23798]: authentication failure; logname= uid=0 euid=0 tty=NODEVssh ruser= rhost=p15105218.pureserver.info  user=root
+Jul  9 22:53:19 combo ftpd[24085]: connection from 206.196.21.129 (host129.206.196.21.maximumasp.com) at Sat Jul  9 22:53:19 2005 
+Jul  9 22:53:19 combo ftpd[24088]: connection from 206.196.21.129 (host129.206.196.21.maximumasp.com) at Sat Jul  9 22:53:19 2005 
+Jul  9 22:53:19 combo ftpd[24087]: connection from 206.196.21.129 (host129.206.196.21.maximumasp.com) at Sat Jul  9 22:53:19 2005 
+Jul  9 22:53:19 combo ftpd[24089]: connection from 206.196.21.129 (host129.206.196.21.maximumasp.com) at Sat Jul  9 22:53:19 2005 
+Jul  9 22:53:19 combo ftpd[24090]: connection from 206.196.21.129 (host129.206.196.21.maximumasp.com) at Sat Jul  9 22:53:19 2005 
+Jul  9 22:53:19 combo ftpd[24091]: connection from 206.196.21.129 (host129.206.196.21.maximumasp.com) at Sat Jul  9 22:53:19 2005 
+Jul  9 22:53:22 combo ftpd[24081]: connection from 206.196.21.129 (host129.206.196.21.maximumasp.com) at Sat Jul  9 22:53:22 2005 
+Jul  9 22:53:22 combo ftpd[24071]: connection from 206.196.21.129 (host129.206.196.21.maximumasp.com) at Sat Jul  9 22:53:22 2005 
+Jul  9 22:53:22 combo ftpd[24077]: connection from 206.196.21.129 (host129.206.196.21.maximumasp.com) at Sat Jul  9 22:53:22 2005 
+Jul  9 22:53:22 combo ftpd[24086]: connection from 206.196.21.129 (host129.206.196.21.maximumasp.com) at Sat Jul  9 22:53:22 2005 
+Jul  9 22:53:22 combo ftpd[24069]: connection from 206.196.21.129 (host129.206.196.21.maximumasp.com) at Sat Jul  9 22:53:22 2005 
+Jul  9 22:53:22 combo ftpd[24074]: connection from 206.196.21.129 (host129.206.196.21.maximumasp.com) at Sat Jul  9 22:53:22 2005 
+Jul  9 22:53:22 combo ftpd[24079]: connection from 206.196.21.129 (host129.206.196.21.maximumasp.com) at Sat Jul  9 22:53:22 2005 
+Jul  9 22:53:22 combo ftpd[24072]: connection from 206.196.21.129 (host129.206.196.21.maximumasp.com) at Sat Jul  9 22:53:22 2005 
+Jul  9 22:53:22 combo ftpd[24076]: connection from 206.196.21.129 (host129.206.196.21.maximumasp.com) at Sat Jul  9 22:53:22 2005 
+Jul  9 22:53:22 combo ftpd[24075]: connection from 206.196.21.129 (host129.206.196.21.maximumasp.com) at Sat Jul  9 22:53:22 2005 
+Jul  9 22:53:22 combo ftpd[24078]: connection from 206.196.21.129 (host129.206.196.21.maximumasp.com) at Sat Jul  9 22:53:22 2005 
+Jul  9 22:53:22 combo ftpd[24080]: connection from 206.196.21.129 (host129.206.196.21.maximumasp.com) at Sat Jul  9 22:53:22 2005 
+Jul  9 22:53:22 combo ftpd[24084]: connection from 206.196.21.129 (host129.206.196.21.maximumasp.com) at Sat Jul  9 22:53:22 2005 
+Jul  9 22:53:22 combo ftpd[24070]: connection from 206.196.21.129 (host129.206.196.21.maximumasp.com) at Sat Jul  9 22:53:22 2005 
+Jul  9 22:53:22 combo ftpd[24083]: connection from 206.196.21.129 (host129.206.196.21.maximumasp.com) at Sat Jul  9 22:53:22 2005 
+Jul  9 22:53:22 combo ftpd[24082]: connection from 206.196.21.129 (host129.206.196.21.maximumasp.com) at Sat Jul  9 22:53:22 2005 
+Jul  9 22:53:22 combo ftpd[24073]: connection from 206.196.21.129 (host129.206.196.21.maximumasp.com) at Sat Jul  9 22:53:22 2005 
+Jul 10 03:55:15 combo ftpd[24513]: connection from 217.187.83.139 () at Sun Jul 10 03:55:15 2005 
+Jul 10 03:55:15 combo ftpd[24512]: connection from 217.187.83.139 () at Sun Jul 10 03:55:15 2005 
+Jul 10 03:55:15 combo ftpd[24519]: connection from 217.187.83.139 () at Sun Jul 10 03:55:15 2005 
+Jul 10 03:55:15 combo ftpd[24514]: connection from 217.187.83.139 () at Sun Jul 10 03:55:15 2005 
+Jul 10 03:55:15 combo ftpd[24515]: connection from 217.187.83.139 () at Sun Jul 10 03:55:15 2005 
+Jul 10 03:55:15 combo ftpd[24516]: connection from 217.187.83.139 () at Sun Jul 10 03:55:15 2005 
+Jul 10 03:55:15 combo ftpd[24517]: connection from 217.187.83.139 () at Sun Jul 10 03:55:15 2005 
+Jul 10 03:55:15 combo ftpd[24521]: connection from 217.187.83.139 () at Sun Jul 10 03:55:15 2005 
+Jul 10 03:55:15 combo ftpd[24520]: connection from 217.187.83.139 () at Sun Jul 10 03:55:15 2005 
+Jul 10 03:55:15 combo ftpd[24522]: connection from 217.187.83.139 () at Sun Jul 10 03:55:15 2005 
+Jul 10 03:55:15 combo ftpd[24518]: connection from 217.187.83.139 () at Sun Jul 10 03:55:15 2005 
+Jul 10 03:55:15 combo ftpd[24523]: connection from 217.187.83.139 () at Sun Jul 10 03:55:15 2005 
+Jul 10 03:55:15 combo ftpd[24524]: connection from 217.187.83.139 () at Sun Jul 10 03:55:15 2005 
+Jul 10 03:55:15 combo ftpd[24525]: connection from 217.187.83.139 () at Sun Jul 10 03:55:15 2005 
+Jul 10 03:55:15 combo ftpd[24526]: connection from 217.187.83.139 () at Sun Jul 10 03:55:15 2005 
+Jul 10 03:55:15 combo ftpd[24527]: connection from 217.187.83.139 () at Sun Jul 10 03:55:15 2005 
+Jul 10 03:55:15 combo ftpd[24528]: connection from 217.187.83.139 () at Sun Jul 10 03:55:15 2005 
+Jul 10 03:55:15 combo ftpd[24529]: connection from 217.187.83.139 () at Sun Jul 10 03:55:15 2005 
+Jul 10 03:55:15 combo ftpd[24530]: connection from 217.187.83.139 () at Sun Jul 10 03:55:15 2005 
+Jul 10 03:55:15 combo ftpd[24531]: connection from 217.187.83.139 () at Sun Jul 10 03:55:15 2005 
+Jul 10 03:55:15 combo ftpd[24532]: connection from 217.187.83.139 () at Sun Jul 10 03:55:15 2005 
+Jul 10 03:55:15 combo ftpd[24533]: connection from 217.187.83.139 () at Sun Jul 10 03:55:15 2005 
+Jul 10 03:55:15 combo ftpd[24534]: connection from 217.187.83.139 () at Sun Jul 10 03:55:15 2005 
+Jul 10 04:04:31 combo su(pam_unix)[24898]: session opened for user cyrus by (uid=0)
+Jul 10 04:04:32 combo su(pam_unix)[24898]: session closed for user cyrus
+Jul 10 04:04:33 combo cups: cupsd shutdown succeeded
+Jul 10 04:04:39 combo cups: cupsd startup succeeded
+Jul 10 04:04:46 combo syslogd 1.4.1: restart.
+Jul 10 04:04:46 combo logrotate: ALERT exited abnormally with [1]
+Jul 10 04:10:47 combo su(pam_unix)[26353]: session opened for user news by (uid=0)
+Jul 10 04:10:47 combo su(pam_unix)[26353]: session closed for user news
+Jul 10 07:24:24 combo ftpd[29726]: connection from 82.83.227.67 (dsl-082-083-227-067.arcor-ip.net) at Sun Jul 10 07:24:24 2005 
+Jul 10 07:24:24 combo ftpd[29725]: connection from 82.83.227.67 (dsl-082-083-227-067.arcor-ip.net) at Sun Jul 10 07:24:24 2005 
+Jul 10 07:24:24 combo ftpd[29719]: connection from 82.83.227.67 (dsl-082-083-227-067.arcor-ip.net) at Sun Jul 10 07:24:24 2005 
+Jul 10 07:24:24 combo ftpd[29723]: connection from 82.83.227.67 (dsl-082-083-227-067.arcor-ip.net) at Sun Jul 10 07:24:24 2005 
+Jul 10 07:24:24 combo ftpd[29720]: connection from 82.83.227.67 (dsl-082-083-227-067.arcor-ip.net) at Sun Jul 10 07:24:24 2005 
+Jul 10 07:24:24 combo ftpd[29717]: connection from 82.83.227.67 (dsl-082-083-227-067.arcor-ip.net) at Sun Jul 10 07:24:24 2005 
+Jul 10 07:24:24 combo ftpd[29718]: connection from 82.83.227.67 (dsl-082-083-227-067.arcor-ip.net) at Sun Jul 10 07:24:24 2005 
+Jul 10 07:24:24 combo ftpd[29724]: connection from 82.83.227.67 (dsl-082-083-227-067.arcor-ip.net) at Sun Jul 10 07:24:24 2005 
+Jul 10 07:24:24 combo ftpd[29722]: connection from 82.83.227.67 (dsl-082-083-227-067.arcor-ip.net) at Sun Jul 10 07:24:24 2005 
+Jul 10 07:24:24 combo ftpd[29727]: connection from 82.83.227.67 (dsl-082-083-227-067.arcor-ip.net) at Sun Jul 10 07:24:24 2005 
+Jul 10 07:24:24 combo ftpd[29721]: connection from 82.83.227.67 (dsl-082-083-227-067.arcor-ip.net) at Sun Jul 10 07:24:24 2005 
+Jul 10 07:24:34 combo ftpd[29728]: connection from 82.83.227.67 (dsl-082-083-227-067.arcor-ip.net) at Sun Jul 10 07:24:34 2005 
+Jul 10 07:24:34 combo ftpd[29730]: connection from 82.83.227.67 (dsl-082-083-227-067.arcor-ip.net) at Sun Jul 10 07:24:34 2005 
+Jul 10 07:24:34 combo ftpd[29731]: connection from 82.83.227.67 (dsl-082-083-227-067.arcor-ip.net) at Sun Jul 10 07:24:34 2005 
+Jul 10 07:24:34 combo ftpd[29732]: connection from 82.83.227.67 (dsl-082-083-227-067.arcor-ip.net) at Sun Jul 10 07:24:34 2005 
+Jul 10 07:24:34 combo ftpd[29729]: connection from 
+
+
+Jul 27 14:41:59 combo kernel: Transparent bridge - 0000:00:1e.0
+Jul 27 14:41:59 combo kernel: PCI: Using IRQ router PIIX/ICH [8086/2410] at 0000:00:1f.0
+Jul 27 14:41:59 combo kernel: apm: BIOS version 1.2 Flags 0x03 (Driver version 1.16ac)
+Jul 27 14:41:59 combo kernel: audit: initializing netlink socket (disabled)
+Jul 27 14:41:54 combo sysctl: kernel.core_uses_pid = 1 
+Jul 27 14:41:59 combo hcid[1690]: HCI daemon ver 2.4 started
+Jul 27 14:41:59 combo bluetooth: hcid startup succeeded
+Jul 27 14:41:59 combo kernel: audit(1122475266.4294965305:0): initialized
+Jul 27 14:41:54 combo network: Setting network parameters:  succeeded 
+Jul 27 14:41:59 combo bluetooth: sdpd startup succeeded
+Jul 27 14:41:59 combo sdpd[1696]: sdpd v1.5 started 
+Jul 27 14:41:59 combo kernel: Total HugeTLB memory allocated, 0
+Jul 27 14:41:54 combo network: Bringing up loopback interface:  succeeded 
+Jul 27 14:41:59 combo kernel: VFS: Disk quotas dquot_6.5.1
+Jul 27 14:41:59 combo kernel: Dquot-cache hash table entries: 1024 (order 0, 4096 bytes)
+Jul 27 14:41:59 combo kernel: SELinux:  Registering netfilter hooks
+Jul 27 14:41:59 combo kernel: Initializing Cryptographic API
+Jul 27 14:41:59 combo kernel: pci_hotplug: PCI Hot Plug PCI Core version: 0.5
+Jul 27 14:42:00 combo kernel: isapnp: Scanning for PnP cards...
+Jul 27 14:42:00 combo kernel: isapnp: No Plug & Play device found
+Jul 27 14:42:00 combo kernel: Real Time Clock Driver v1.12
+
+
+Jul 27 14:42:00 combo kernel: Linux agpgart interface v0.100 (c) Dave Jones
+
+
+


### PR DESCRIPTION
Fix #1, #2, #3

### Changes

1. If a filter is provided, the text/keyword will be searched first, then return the latest `n` number of lines.
2. Empty lines are ignored and not returned