### PR TITLE
Fix text clipping

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,7 @@
 {
   "tabWidth": 2,
   "useTabs": false,
+  "plugins": ["@trivago/prettier-plugin-sort-imports"],
   "importOrderSeparation": true,
   "importOrderSortSpecifiers": true
 }

--- a/src/api/v1/services/logService.ts
+++ b/src/api/v1/services/logService.ts
@@ -69,7 +69,7 @@ export class LogService implements ILogService {
       let readData = "";
 
       // Break out from the loop if n number of lines is met
-      while (position > 0 /**&& lineCount !== n+1*/) {
+      while (position > 0) {
         const currentChunk = await this._readFileChunk(handle, position);
         readData = currentChunk + readData;
 

--- a/tests/apiLogs.test.ts
+++ b/tests/apiLogs.test.ts
@@ -1,18 +1,26 @@
 /* eslint no-unused-labels: "off" */
+
 /* eslint @typescript-eslint/no-unsafe-member-access: "off" */
+
 /* eslint @typescript-eslint/no-unsafe-call: "off" */
 
+/* eslint @typescript-eslint/no-unsafe-return: "off" */
 import app, { server } from "@/index";
 import path from "path";
 import request from "supertest";
 
 const VAR_LOG_DIR = process.env.VAR_LOG_DIR ?? path.join(__dirname, "samples");
 
+// Set smaller chunk size for text clipping scenarios
+jest.mock("@/api/v1/configs/logConfig", () => ({
+  ...jest.requireActual("@/api/v1/configs/logConfig"),
+  DEFAULT_BUFFER_CHUNK_SIZE_BYTES: 10,
+}));
+
 describe("GET /api/v1/logs", () => {
   // Close the expressjs server once all tests are completed
   afterAll(() => {
     server.close();
-    jest.resetAllMocks();
   });
 
   it("400 Bad Request - Retrieve logs with missing filename query param", async () => {


### PR DESCRIPTION
Fix #2 

* Tested using a smaller chunk size value `DEFAULT_BUFFER_CHUNK_SIZE_BYTES=10`, which is more susceptible to text clipping
* `_tailLogNoFilter` method: Moved the lineCount logic within the while loop
* `_grepLinesFromEnd` method: Cannot remove empty lines, this is used for stitching chunks.